### PR TITLE
Now you can define "id" for input

### DIFF
--- a/lib/components/ModernDatepicker.js
+++ b/lib/components/ModernDatepicker.js
@@ -143,11 +143,12 @@ class ModernDatepicker extends Component {
 
   render() {
     const { showContainer, setViewFor, dateToEdit, isValid,  yearBlock } = this.state;
-    const { format, date, placeholder, showBorder, className, icon, maxDate, minDate } = this.props;  
+    const { format, date, placeholder, showBorder, className, id, icon, maxDate, minDate } = this.props;
     return (
       <Container onBlur={(e) => this.onBlur(e)}>
         <Input
           className={className}
+          id={id}
           onChange={(e) => e.preventDefault()}
           onFocus={() => this.toggleCalendar(true)}
           placeholder={placeholder}


### PR DESCRIPTION
When you use the **label** tag as the wrapper for **ModernDatepicker**, you need the id attribute for the **input** tag to set the relationship between the elements

Now you can define the "id" attribute, for example:

```  render() {
    return (
      <div className="event-box__date">
        <label htmlFor="date">Date
          <ModernDatepicker
            id="date"
            date={this.state.startDate}
            format={'DD-MM-YYYY'}
            onChange={(date) => this.handleChange(date)}
          >
          </ModernDatepicker>
        </label>
      </div>
    );
  }```