### PR TITLE
New option "label"

### DIFF
--- a/lib/components/ModernDatepicker.js
+++ b/lib/components/ModernDatepicker.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import Label from '../elements/Label';
 import Input from '../elements/Input';
 import Icon from '../elements/Icon';
 import Container from '../elements/Container';
@@ -143,9 +144,10 @@ class ModernDatepicker extends Component {
 
   render() {
     const { showContainer, setViewFor, dateToEdit, isValid,  yearBlock } = this.state;
-    const { format, placeholder, showBorder, className, id, icon, maxDate, minDate } = this.props;
+    const { format, placeholder, showBorder, className, id, icon, maxDate, minDate, label } = this.props;
     return (
       <Container onBlur={(e) => this.onBlur(e)}>
+        {label && <Label htmlFor={id} >{label}</Label>}
         <Input
           className={className}
           id={id}
@@ -207,6 +209,7 @@ ModernDatepicker.propTypes = {
   ]),
   format: PropTypes.string,
   id: PropTypes.string,
+  label: PropTypes.string,
   maxDate:PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object

--- a/lib/components/ModernDatepicker.js
+++ b/lib/components/ModernDatepicker.js
@@ -116,6 +116,7 @@ class ModernDatepicker extends Component {
   }
 
   checkAndReturnDate() {
+    moment.locale(this.props.lang);
     const { isValid, isMaxValid, isMinValid } = this.state;
     const { format, date, maxDate, minDate } = this.props;
     const currentDate = date ? moment(date, format || 'DD-MM-YYYY') : '';  
@@ -134,7 +135,7 @@ class ModernDatepicker extends Component {
       return 'Invalid max date';
     }
     else if (date){
-      return moment(date, format || 'DD-MM-YYYY').format(format || 'DD-MM-YYYY');
+      return moment(date, format || 'DD-MM-YYYY').locale(this.props.lang).format(format || 'DD-MM-YYYY');
     }
     else {
       return '';

--- a/lib/elements/Icon.js
+++ b/lib/elements/Icon.js
@@ -6,9 +6,8 @@ const Img = styled.img`
     width: 22px;
     height: 22px;
     position : absolute;
-    top: 0;
     cursor: pointer;
-    bottom: 0;
+    bottom: 10px;
     margin: auto;
     right: 10px;
 `;

--- a/lib/elements/Label.js
+++ b/lib/elements/Label.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const Label = styled.label`
+  font-size: 15px;
+  color: #000;
+`;
+
+export default Label;


### PR DESCRIPTION
Hi!
I am sure this option will be useful because everyone use `label` for `input` tag.

Now you can add `label` tag.

```
  <ModernDatepicker
    label="Date"
    id="dateId"
    date={this.state.startDate}
    format={'DD-MM-YYYY'}
    onChange={(date) => this.handleChange(date)}
  />
``` 

NOTE: don't forget to specify `id` for the `ModernDatepicker` component because the string of the `id` will be in the `for` attribute in the label tag